### PR TITLE
fix: switch name to ascii

### DIFF
--- a/draft-ietf-v6ops-6mops.xml
+++ b/draft-ietf-v6ops-6mops.xml
@@ -1122,7 +1122,7 @@ IPv6-mostly networks have the same privacy considerations as other Dual-stacked 
 <section anchor="Acknowledgements" numbered="false">
 <name>Acknowledgements</name>
 <t>
-Thanks to Mohamed Boucadair, Brian Carpenter, Stuart Cheshire, Tim Chown, Joe Clarke, Lorenzo Colitti, Tom Costello, Jeremy Duncan, David Farmer, Sorah Fukumori, Götz Görisch, Warren Kumari, Eliot Lear, Jordi Palet, Tom Petch, Michael Richardson, Philipp Tiesel, Arie Vayner, XiPeng Xiao, Matsuzaki Yoshinobu for the discussions, the feedback, and all contribution.
+Thanks to Mohamed Boucadair, Brian Carpenter, Stuart Cheshire, Tim Chown, Joe Clarke, Lorenzo Colitti, Tom Costello, Jeremy Duncan, David Farmer, Sorah Fukumori, Goetz Goerisch, Warren Kumari, Eliot Lear, Jordi Palet, Tom Petch, Michael Richardson, Philipp Tiesel, Arie Vayner, XiPeng Xiao, Matsuzaki Yoshinobu for the discussions, the feedback, and all contribution.
 </t>
 </section>
 


### PR DESCRIPTION
Thank you for your acknowledgment.
To be consistent switch name to ASCII.

Thanks for considering.